### PR TITLE
[voqinbandif] Support for inband port as regular port

### DIFF
--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -94,6 +94,11 @@ class LldpManager(daemon_base.DaemonBase):
         """
         port_desc = None
 
+        # Skip port name prefixed with "Inband". These are recycle ports exposed in PORT_TABLE for
+        # asic-to-asic communication in VOQ based chassis system. We do not configure LLDP on these.
+        if 'Inband' in port_name:
+            return
+
         # Retrieve all entires for this port from the Port table
         port_table = swsscommon.Table(self.config_db, swsscommon.CFG_PORT_TABLE_NAME)
         (status, fvp) = port_table.get(port_name)

--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -22,6 +22,7 @@ try:
 
     from sonic_py_common import daemon_base
     from swsscommon import swsscommon
+    from sonic_py_common.interface import inband_prefix
 except ImportError as err:
     raise ImportError("%s - required module not found" % str(err))
 
@@ -94,9 +95,9 @@ class LldpManager(daemon_base.DaemonBase):
         """
         port_desc = None
 
-        # Skip port name prefixed with "Inband". These are recycle ports exposed in PORT_TABLE for
+        # Skip inband interface prefixes. These are recycle ports exposed in PORT_TABLE for
         # asic-to-asic communication in VOQ based chassis system. We do not configure LLDP on these.
-        if 'Inband' in port_name:
+        if port_name.startswith(inband_prefix()):
             return
 
         # Retrieve all entires for this port from the Port table

--- a/dockers/docker-lldp/supervisord.conf.j2
+++ b/dockers/docker-lldp/supervisord.conf.j2
@@ -45,9 +45,9 @@ dependent_startup_wait_for=rsyslogd:running
 # - `-ddd` means to stay in foreground, log warnings and info to console
 # - `-dddd` means to stay in foreground, log all to console
 {% if DEVICE_METADATA['localhost']['sub_role'] is defined and DEVICE_METADATA['localhost']['sub_role']|length %}
-command=/usr/sbin/lldpd -d -I Ethernet* -C Ethernet*
+command=/usr/sbin/lldpd -d -I Ethernet*,Inband* -C Ethernet*
 {% else %}
-command=/usr/sbin/lldpd -d -I Ethernet*,eth0 -C eth0
+command=/usr/sbin/lldpd -d -I Ethernet*,Inband*,eth0 -C eth0
 {% endif %}
 priority=3
 autostart=false

--- a/dockers/docker-lldp/supervisord.conf.j2
+++ b/dockers/docker-lldp/supervisord.conf.j2
@@ -45,9 +45,9 @@ dependent_startup_wait_for=rsyslogd:running
 # - `-ddd` means to stay in foreground, log warnings and info to console
 # - `-dddd` means to stay in foreground, log all to console
 {% if DEVICE_METADATA['localhost']['sub_role'] is defined and DEVICE_METADATA['localhost']['sub_role']|length %}
-command=/usr/sbin/lldpd -d -I Ethernet*,Inband* -C Ethernet*
+command=/usr/sbin/lldpd -d -I Ethernet* -C Ethernet*
 {% else %}
-command=/usr/sbin/lldpd -d -I Ethernet*,Inband*,eth0 -C eth0
+command=/usr/sbin/lldpd -d -I Ethernet*,eth0 -C eth0
 {% endif %}
 priority=3
 autostart=false

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -90,6 +90,16 @@ fi
 if [ "$conn_chassis_db" == "1" ]; then
    if [ -f /usr/share/sonic/virtual_chassis/coreportindexmap.ini ]; then
       cp /usr/share/sonic/virtual_chassis/coreportindexmap.ini /usr/share/sonic/hwsku/
+
+      pushd /usr/share/sonic/hwsku
+
+      # filter available front panel ports in coreportindexmap.ini
+      [ -f coreportindexmap.ini.orig ] || cp coreportindexmap.ini coreportindexmap.ini.orig
+      for p in $(ip link show | grep -oE "eth[0-9]+" | grep -v eth0); do
+          grep ^$p: coreportindexmap.ini.orig
+      done > coreportindexmap.ini
+
+      popd
    fi
 fi
 

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -14,7 +14,7 @@ SONIC_INTERFACE_PREFIXES = {
     "Vlan": "Vlan",
     "Loopback": "Loopback",
     "Ethernet-Backplane": "Ethernet-BP",
-    "Inband": "Inband"
+    "Ethernet-Inband": "Ethernet-IB"
 }
 
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
@@ -53,7 +53,7 @@ def inband_prefix():
     """
     Retrieves the SONIC recycle port inband interface name prefix.
     """
-    return SONIC_INTERFACE_PREFIXES["Inband"]
+    return SONIC_INTERFACE_PREFIXES["Ethernet-Inband"]
 
 def get_interface_table_name(interface_name):
     """Get table name by interface_name prefix

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -13,7 +13,8 @@ SONIC_INTERFACE_PREFIXES = {
     "PortChannel": "PortChannel",
     "Vlan": "Vlan",
     "Loopback": "Loopback",
-    "Ethernet-Backplane": "Ethernet-BP"
+    "Ethernet-Backplane": "Ethernet-BP",
+    "Inband": "Inband"
 }
 
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
@@ -47,6 +48,12 @@ def loopback_prefix():
     Retrieves the SONIC Loopback interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["Loopback"]
+
+def inband_prefix():
+    """
+    Retrieves the SONIC Broadcom recycle port inband interface name prefix.
+    """
+    return SONIC_INTERFACE_PREFIXES["Inband"]
 
 def get_interface_table_name(interface_name):
     """Get table name by interface_name prefix

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -51,7 +51,7 @@ def loopback_prefix():
 
 def inband_prefix():
     """
-    Retrieves the SONIC Broadcom recycle port inband interface name prefix.
+    Retrieves the SONIC recycle port inband interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["Inband"]
 


### PR DESCRIPTION
Signed-off-by: vedganes <vedavinayagam.ganesan@nokia.com>

**- Why I did it**

Inband port can be made available in PORT table. But regular port handlngs are
not applicable for Inband port. 

Changes in this PR are to make LLDP to consider Inband port and to avoid regular
port handling on Inband port.

Currently the Inband interface is used for VOQ chassis systems for asic to asic communications.

**- How I did it**

 - Changes done in supervisor conf for LLDP to include Inband in the interface list
 - Changes done in platform common files to handle Inand port similar to how backplane port is handled
 
**- How to verify it**

- Expose a port with name prefixed with "Inband" to SONiC via port_config.ini
- Have an entry in the PORT table for this port with name "Inband"
- When the system is booted, there should not be errors related to Inband interface

**- Which release branch to backport (provide reason below if selected)**

**- Description for the changelog**
